### PR TITLE
Prompt for deploy properties

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -1,6 +1,10 @@
 <project name="deploy" default="deploy">
 
   <target name="deploy" description="Builds separate artifact and pushes to git.remotes defined project.yml.">
+    
+    <!-- Prompt for user input -->
+    <propertyprompt propertyName="deploy.commitMsg" useExistingValue="true" promptText="Enter a valid commit message" promptCharacter=":" />
+    <propertyprompt propertyName="deploy.branch" useExistingValue="true" promptText="Enter a deploy branch" promptCharacter=":" />
 
     <!-- Check necessary runtime parameters. -->
     <if>


### PR DESCRIPTION
Adds property prompts so users don't have to remember the syntax for passing options to `blt deploy`. This still allows for properties to be passed in via the `-D` option (so CI can still deploy without input) but for local deploys a user doesn't need to add additional options.

The if check needs to remain as the `propertyprompt` unless a default value is added as the target allows you to skip entering a value.
